### PR TITLE
FixBug: Play button in Pokemon Selection Scene wasn't working properly.

### DIFF
--- a/src/FinalMonster/Graphics/Components/SelectionScene.java
+++ b/src/FinalMonster/Graphics/Components/SelectionScene.java
@@ -95,11 +95,6 @@ public class SelectionScene extends BorderPane {
 
 	@FXML
 	public void addPokemons(ActionEvent e) {
-		if ( playerPokemons.size() > 1 && playerPokemons.size() < 3 ) {
-			play.setDisable(false);
-		} else {
-			play.setDisable(true);
-		}
 		RadioButton poke = (RadioButton) e.getSource();
 		if ( !poke.isSelected() ) {
 			System.out.println(playerPokemons.remove(PokemonList.getPokemon(poke.getId())));
@@ -108,6 +103,12 @@ public class SelectionScene extends BorderPane {
 			System.out.println(poke.getId());
 		}
 		System.out.println(playerPokemons.size());
+
+		if ( playerPokemons.size() == 3 ) {
+			play.setDisable(false);
+		} else {
+			play.setDisable(true);
+		}
 	}
 
 	@FXML


### PR DESCRIPTION
When the user had selected 2 pokemons and then he deselect one of them Play button will work and the user have one pokemon, and if the user selected 4 and then he deselect one of them play button won't work even that the user have 3 pokemons.